### PR TITLE
fix(scheduler.py): Disable call to self.analytics(main_uid) every minutes

### DIFF
--- a/naas/runner/scheduler.py
+++ b/naas/runner/scheduler.py
@@ -334,7 +334,8 @@ class Scheduler:
                     "duration": duration_total,
                 }
             )
-            await self.analytics(main_uid)
+            # We disable this for now as it is not used and is therefore filling up the database.
+            #await self.analytics(main_uid)
         except Exception as e:
             tb = traceback.format_exc()
             duration_total = time.time() - all_start_time

--- a/naas/runner/scheduler.py
+++ b/naas/runner/scheduler.py
@@ -335,7 +335,7 @@ class Scheduler:
                 }
             )
             # We disable this for now as it is not used and is therefore filling up the database.
-            #await self.analytics(main_uid)
+            # await self.analytics(main_uid)
         except Exception as e:
             tb = traceback.format_exc()
             duration_total = time.time() - all_start_time


### PR DESCRIPTION
The goal here is to disable the call to self.analytics(main_uid) because its creating new rows in the database every minutes for every jupyterlab running. They should be removed automatically when they are consumed but we are, as of today, not cconsuming them.