### PR TITLE
fix(jobs.list): Return 404 instead of 500 when no jobs are found for a Notebook (path)

### DIFF
--- a/naas/manager.py
+++ b/naas/manager.py
@@ -3,6 +3,7 @@ from .ntypes import (
     t_performance,
     t_storage,
     t_job,
+    t_job_not_found,
     t_env,
     t_skip,
     t_send,
@@ -280,9 +281,12 @@ class Manager:
                 headers=self.headers,
                 params={"path": current_file, "type": self.__filetype, "mode": mode},
             )
-            r.raise_for_status()
+            if r.status_code != 404:
+                r.raise_for_status()
             res = r.json()
-            if res.get("status") == t_error or res.get("status") == t_skip:
+            if (
+                res.get("status") == t_error or res.get("status") == t_skip
+            ) and res.get("error") != t_job_not_found:
                 raise ValueError(f"❌ Cannot list your file {path}")
             if res.get("files", None) and len(res.get("files", [])) > 0:
                 return pd.DataFrame(data=res.get("files", []))

--- a/naas/ntypes.py
+++ b/naas/ntypes.py
@@ -13,6 +13,7 @@ t_secret = "secret"
 t_tz = "timezone"
 t_performance = "performance"
 t_job = "job"
+t_job_not_found = "job not found"
 t_env = "env"
 t_log = "log"
 

--- a/naas/runner/controllers/jobs.py
+++ b/naas/runner/controllers/jobs.py
@@ -100,7 +100,7 @@ class JobsController(HTTPMethodView):
         job = await self.__jobs.find_by_path(uid, path, cur_type)
         if not job:
             return response.json(
-                {"status": t_error, "error": "job not found"}, status=500
+                {"status": t_error, "error": "job not found"}, status=404
             )
         if cur_mode and cur_mode == "list_history":
             job["files"] = self.__jobs.list_files(uid, path, cur_type)


### PR DESCRIPTION
We were raising an error saying that we cannot list jobs for a file when in fact we could but we were just not finding any. Updated the logic to not get any errors but a log saying that we did not found the files in production.