### PR TITLE
fix(install-and-Dockerfile.dev): Fixed livereload for development environment

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -6,7 +6,7 @@ ARG VCS_REF
 
 ENV NAAS_INSTALL_SUPP 'no'
 ENV JUPYTER_ENABLE_LAB 'yes'
-ENV NB_USER=bob
+ENV NB_USER=ftp
 
 USER root
 LABEL org.label-schema.build-date=$BUILD_DATE \
@@ -37,3 +37,4 @@ COPY scripts /etc/naas/scripts
 COPY custom /etc/naas/custom
 RUN /etc/naas/scripts/install_supp
 RUN /etc/naas/scripts/customize
+RUN rm -rf /home/$NB_USER/naas

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -37,4 +37,3 @@ COPY scripts /etc/naas/scripts
 COPY custom /etc/naas/custom
 RUN /etc/naas/scripts/install_supp
 RUN /etc/naas/scripts/customize
-RUN rm -rf /home/$NB_USER/naas

--- a/install
+++ b/install
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -x
+
 BUILD="YES"
 SUPP="NO"
 N_ENV="dev"


### PR DESCRIPTION
Live reload was broken because we were using user "Bob" instead of "ftp" in Dockerfile.dev. Also added set -x in install script to see what is being executed.