### PR TITLE
fix(naas-runner): Run naas runner in a Thread and restart it automatically

### DIFF
--- a/custom/jupyter_server_config.py
+++ b/custom/jupyter_server_config.py
@@ -3,9 +3,12 @@
 
 import subprocess
 import os
+import logging
+import threading
+import time
 
 c = get_config()
-c.ServerApp.ip = '0.0.0.0'
+c.ServerApp.ip = "0.0.0.0"
 c.ServerApp.port = 8888
 
 naas_port = 5000
@@ -14,27 +17,41 @@ c.ServerApp.open_browser = False
 c.ServerApp.webbrowser_open_new = 0
 
 c.ServerApp.tornado_settings = {
-    'headers': {
-        'Content-Security-Policy': 'frame-ancestors self ' + os.environ.get('ALLOWED_IFRAME', '')
+    "headers": {
+        "Content-Security-Policy": "frame-ancestors self "
+        + os.environ.get("ALLOWED_IFRAME", "")
     }
 }
 
 c.ServerProxy.servers = {
-    'naas': {
-        'launcher_entry': {
-            'enabled': True,
-            'icon_path': '/etc/naas/custom/naas_fav.svg',
-            'title': 'Naas manager',
+    "naas": {
+        "launcher_entry": {
+            "enabled": True,
+            "icon_path": "/etc/naas/custom/naas_fav.svg",
+            "title": "Naas manager",
         },
-        'new_browser_tab': False,
-        'timeout': 30,
-        'command': ["redir", ":{port}", f":{naas_port}"],
+        "new_browser_tab": False,
+        "timeout": 30,
+        "command": ["redir", ":{port}", f":{naas_port}"],
     }
 }
 
 # Change default umask for all subprocesses of the notebook server if set in
 # the environment
-if 'NB_UMASK' in os.environ:
-    os.umask(int(os.environ['NB_UMASK'], 8))
+if "NB_UMASK" in os.environ:
+    os.umask(int(os.environ["NB_UMASK"], 8))
 
-subprocess.Popen(['python', '-m', 'naas.runner', '-p', f'{naas_port}'])
+
+def naasRunner(naas_port):
+    while True:
+        logging.info("Starting naas runner on port {}.".format(naas_port))
+        p = subprocess.Popen(["python", "-m", "naas.runner", "-p", f"{naas_port}"])
+        p.wait()
+        logging.info("Naas Runner exited !")
+        logging.info(p.stdout)
+        logging.info(p.stderr)
+        time.sleep(1)
+
+
+runner = threading.Thread(target=naasRunner, args=(naas_port,))
+runner.start()


### PR DESCRIPTION
Naas runner was not monitored and not being restarted on failure. Now it will be restarted on each exit.

This is not the final design but it's a good fix while waiting for complete rewriting of naas running scheduling logic.