### PR TITLE
fix(naas/runner/jobs.py): Fix job not returning "runs" because of a JSON exception being triggered

### DIFF
--- a/naas/runner/jobs.py
+++ b/naas/runner/jobs.py
@@ -348,8 +348,13 @@ class Jobs:
                     for d in data:
                         try:
                             d["path"] = d["path"] if prodPath else cpath(d["path"])
-                            d["runs"] = json.loads(d.get("runs", "[]"))
-                        except Exception:
+                            runs = d.get("runs", "[]")
+                            if type(runs) is str:
+                                d["runs"] = json.loads(runs)
+                            else:
+                                d["runs"] = runs
+                        except Exception as e:
+                            print(e)
                             d["runs"] = []
                             pass
         except Exception as e:


### PR DESCRIPTION
Added a type verification on "runs" property of a Job when listing them. It seems that most of the time they are already loaded into Python objects and we were forcing the use of `json.loads()` on them which was raising an exception. We are now type checking to see if we need to run json.loads or not. We are also printing the Exception on stdout if we catch any.