### PR TITLE
fix(papermill): Surround Papermill import with warning catching logic

### DIFF
--- a/naas/runner/custom_papermill.py
+++ b/naas/runner/custom_papermill.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 # Temporary way to remove Papermill import warnings. Shuold be fixed when reaching Papermill 2.3.4
 import warnings
+
 with warnings.catch_warnings():
     warnings.simplefilter("ignore")
     from papermill.log import logger
@@ -27,7 +28,7 @@ with warnings.catch_warnings():
         add_builtin_parameters,
         parameterize_notebook,
         parameterize_path,
-        )
+    )
 
 import json
 

--- a/naas/runner/custom_papermill.py
+++ b/naas/runner/custom_papermill.py
@@ -5,25 +5,30 @@ from naas.runner.env_var import cpath
 import nbformat
 from pathlib import Path
 
-from papermill.log import logger
-from papermill.iorw import (
-    get_pretty_path,
-    local_file_io_cwd,
-    load_notebook_node,
-    write_ipynb,
-)
-from papermill.engines import papermill_engines
-from papermill.execute import (
-    prepare_notebook_metadata,
-    remove_error_markers,
-    raise_for_execution_errors,
-)
-from papermill.utils import chdir
-from papermill.parameterize import (
-    add_builtin_parameters,
-    parameterize_notebook,
-    parameterize_path,
-)
+# Temporary way to remove Papermill import warnings. Shuold be fixed when reaching Papermill 2.3.4
+import warnings
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore")
+    from papermill.log import logger
+    from papermill.iorw import (
+        get_pretty_path,
+        local_file_io_cwd,
+        load_notebook_node,
+        write_ipynb,
+    )
+    from papermill.engines import papermill_engines
+    from papermill.execute import (
+        prepare_notebook_metadata,
+        remove_error_markers,
+        raise_for_execution_errors,
+    )
+    from papermill.utils import chdir
+    from papermill.parameterize import (
+        add_builtin_parameters,
+        parameterize_notebook,
+        parameterize_path,
+        )
+
 import json
 
 

--- a/naas/runner/notebooks.py
+++ b/naas/runner/notebooks.py
@@ -1,4 +1,3 @@
-
 from .custom_papermill import execute_notebook
 from naas.ntypes import (
     t_notebook,
@@ -18,8 +17,10 @@ from naas.ntypes import (
 from nbconvert import HTMLExporter
 from .env_var import cpath, n_env
 from sanic import response
+
 # # Temporary way to remove Papermill import warnings. Shuold be fixed when reaching Papermill 2.3.4
 import warnings
+
 with warnings.catch_warnings():
     warnings.simplefilter("ignore")
     import papermill as pm

--- a/naas/runner/notebooks.py
+++ b/naas/runner/notebooks.py
@@ -1,3 +1,4 @@
+
 from .custom_papermill import execute_notebook
 from naas.ntypes import (
     t_notebook,
@@ -17,7 +18,11 @@ from naas.ntypes import (
 from nbconvert import HTMLExporter
 from .env_var import cpath, n_env
 from sanic import response
-import papermill as pm
+# # Temporary way to remove Papermill import warnings. Shuold be fixed when reaching Papermill 2.3.4
+import warnings
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore")
+    import papermill as pm
 import traceback
 import datetime
 import shutil


### PR DESCRIPTION
The goal of this pull request is to remove `Papermill` import warnings while we wait for a fix from Papermill themselves.