### PR TITLE
refactor(onboarding,downloader): Remove dl_ prefix on downloaded files

### DIFF
--- a/naas/onboarding.py
+++ b/naas/onboarding.py
@@ -2,6 +2,9 @@ from naas.runner.env_var import n_env
 import urllib.parse
 import requests
 import os
+from os import path
+import pathlib
+
 
 __jup_def_set_workspace = "/etc/naas/custom/set_workspace.json"
 __jup_def_set_workspace_browser = "/etc/naas/custom/set_workspace_browser.json"
@@ -10,6 +13,16 @@ __github_repo = "jupyter-naas/starters"
 __github_brach = "main"
 __github_api_url = "https://api.github.com/repos/{REPO}/git/trees/{BRANCH}?recursive=1"
 __github_base_url = "https://github.com/{REPO}/blob/{BRANCH}/"
+
+
+def __generate_unique_path(filepath):
+    count = 1
+    unique_path = filepath
+    while path.exists(unique_path):
+        p = pathlib.Path(filepath)
+        unique_path = path.join(p.parents[0], f"{p.stem}_({count}){p.suffix}")
+        count += 1
+    return unique_path
 
 
 def download_file(url, file_name=None):
@@ -48,6 +61,7 @@ def download_file(url, file_name=None):
         content = r.content
     if content.startswith(b"ERROR"):
         file_name = "dl_error.txt"
+    file_name = __generate_unique_path(file_name)
     with open(file_name, "wb") as f:
         f.write(content)
         f.close()

--- a/naas/onboarding.py
+++ b/naas/onboarding.py
@@ -20,7 +20,7 @@ def download_file(url, file_name=None):
     elif file_name not in ".":
         file_name = f"{file_name}.ipynb"
 
-    file_name = f"dl_{file_name}"
+    file_name = f"{file_name}"
     if "://github.com" in raw_target:
         raw_target = raw_target.replace(
             "https://github.com/", "https://raw.githubusercontent.com/"

--- a/naas/runner/controllers/downloader.py
+++ b/naas/runner/controllers/downloader.py
@@ -44,7 +44,7 @@ class DownloaderController(HTTPMethodView):
                     {"id": uid, "type": t_downloader, "status": t_send, "filepath": url}
                 )
                 return json({"status": t_error, "error": str(e), "tb": str(tb)})
-        wp_set_for_open_filebrowser(file_name)
+        # wp_set_for_open_filebrowser(file_name)
         if mode_api is None:
             redirect_to = f"{n_env.user_url}/lab/tree/{file_name}"
             return redirect(redirect_to)


### PR DESCRIPTION
Simply remove `dl_` prefix as it does not really make sense. Instead we are creating non overlapping names:
- `notebook_(1).ipynb`
- `notebook_(2).ipynb`
- `notebook_(3).ipynb`
- ...