### PR TITLE
Create production symlink.

### DIFF
--- a/naas/__init__.py
+++ b/naas/__init__.py
@@ -44,6 +44,12 @@ def version():
 
 n_env.version = __version__
 
+# Create Production symlink.
+try:
+    os.makedirs('/home/ftp/.naas/home/ftp', exist_ok=True)
+    os.symlink('/home/ftp/.naas/home/ftp', '⚡Production')
+except FileExistsError as e:
+    print(e)
 
 def get_last_version():
     url = f"https://api.github.com/repos/{__github_repo}/tags"


### PR DESCRIPTION
With the intent to give more visibility to users on production filesystem, this pull request is here to automatically create a symbolic link to provide access to the production directory.

When the naas manager is being loaded, we are creating needing directories using `os.makedirs` and then the symlink.

Here is what it looks like:
<img width="335" alt="image" src="https://user-images.githubusercontent.com/22365519/130767937-62e1604e-7fdd-4826-b6d7-f74742ae6208.png">

