### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-with open("README.md", "r") as fh:
+with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 NDV = "0.70.9"


### PR DESCRIPTION
fix pip install failure
UnicodeDecodeError: 'gbk' codec can't decode byte 0xa1 in position 2714: illegal multibyte sequence

Windows 10 20H2 19042.867
Python 3.9.1 64-bit
pip 20.2.3