### PR TITLE
fix(Jobs): Set scheduler status from started to installed at naas-run…

### DIFF
--- a/naas/runner/jobs.py
+++ b/naas/runner/jobs.py
@@ -83,6 +83,7 @@ class Jobs:
         else:
             uid = str(uuid.uuid4())
             self.__df = self.__get_save_from_file(uid)
+            self.__df.loc[self.__df["status"] == "started", "status"] = "installed"
         self.__cleanup_jobs()
 
     def reload_jobs(self):


### PR DESCRIPTION
This pull request make sure that jobs with status to `started` are reset to `installed` when naas-runner is starting.