### PR TITLE
fix: Rename starter and production folder. Also pull __templates__

### DIFF
--- a/custom/jupyter_server_config.py
+++ b/custom/jupyter_server_config.py
@@ -67,8 +67,24 @@ def naasStarter():
         os.system('rm /home/ftp/Welcome_to_Naas.ipynb')
         time.sleep(ONE_HOUR)
 
+def naasTemplates():
+    while True:
+        logging.info("Refreshing templates")
+        folder_name = '__templates__'
+
+        # Change this to remove a folder from the home directory of the user.
+        #os.system('rm -rf /home/ftp/')
+
+        os.system('git clone https://github.com/jupyter-naas/awesome-notebooks.git /home/ftp/.naas/awesome-notebooks|| (cd /home/ftp/.naas/awesome-notebooks && git reset --hard && git pull)')
+        os.system(f'mkdir -p "/home/ftp/{folder_name}"')
+        os.system(f'cp -r /home/ftp/.naas/awesome-notebooks/* "/home/ftp/{folder_name}" && rm "/home/ftp/{folder_name}/README.md"')
+        time.sleep(ONE_HOUR)
+
 runner = threading.Thread(target=naasRunner, args=(naas_port,))
 runner.start()
 
 starter = threading.Thread(target=naasStarter, args=())
 starter.start()
+
+templates = threading.Thread(target=naasTemplates, args=())
+templates.start()

--- a/custom/jupyter_server_config.py
+++ b/custom/jupyter_server_config.py
@@ -56,10 +56,10 @@ ONE_HOUR:float = 3600.0
 def naasStarter():
     while True:
         logging.info("Refreshing naas starter")
-        folder_name = '⚡ Get started with Naas'
+        folder_name = '__tutorials__'
 
         # Change this to remove a folder from the home directory of the user.
-        os.system('rm -rf /home/ftp/old_folder_name_42')
+        os.system('rm -rf /home/ftp/⚡ Get started with Naas')
 
         os.system('git clone https://github.com/jupyter-naas/starters.git /home/ftp/.naas/starters|| (cd /home/ftp/.naas/starters && git reset --hard && git pull)')
         os.system(f'mkdir -p "/home/ftp/{folder_name}"')

--- a/naas/runner/__main__.py
+++ b/naas/runner/__main__.py
@@ -7,7 +7,8 @@ def createProductionSymlink():
     # Create Production symlink.
     try:
         os.makedirs("/home/ftp/.naas/home/ftp", exist_ok=True)
-        os.symlink("/home/ftp/.naas/home/ftp", "/home/ftp/⚡ → Production")
+        os.symlink("/home/ftp/.naas/home/ftp", "/home/ftp/__production__")
+        os.remove('/home/ftp/⚡ → Production')
     except FileExistsError as e:
         print(e)
         pass

--- a/naas/runner/__main__.py
+++ b/naas/runner/__main__.py
@@ -8,7 +8,7 @@ def createProductionSymlink():
     try:
         os.makedirs("/home/ftp/.naas/home/ftp", exist_ok=True)
         os.symlink("/home/ftp/.naas/home/ftp", "/home/ftp/__production__")
-        os.remove('/home/ftp/⚡ → Production')
+        os.remove("/home/ftp/⚡ → Production")
     except FileExistsError as e:
         print(e)
         pass

--- a/naas/runner/assets/manager.html
+++ b/naas/runner/assets/manager.html
@@ -1132,7 +1132,7 @@
                 </vue-good-table>
             </div>
             <div v-else-if="jobsActive">
-                <p class="pb-3 text-white">Monitor active features in the "⚡ → Production" folder of your JupyterLab: scheduler, asset, webhook, notification.</p>
+                <p class="pb-3 text-white">Monitor active features in the "__production__" folder of your JupyterLab: scheduler, asset, webhook, notification.</p>
                 <vue-good-table class="border-object" :columns="columns_jobs" :rows="jobs" :search-options="{
                         enabled: true,
                         externalQuery: filter


### PR DESCRIPTION
This pull request will make the user home look like so:

<img width="330" alt="image" src="https://user-images.githubusercontent.com/22365519/196691585-eccc5a8b-56ac-4a0f-9708-359aa6055e27.png">


`__templates__` and `__tutorials__` are being overwritten every hour with an automatic pull from the following repositories:
- https://github.com/jupyter-naas/starters
- https://github.com/jupyter-naas/awesome-notebooks