### PR TITLE
feat: Introduced User-Defined outputs_path for Pipeline Execution

### DIFF
--- a/.docker/dev/docker-entrypoint.sh
+++ b/.docker/dev/docker-entrypoint.sh
@@ -18,5 +18,7 @@ pip install -ve '/home/ftp/naas/extensions/naasai'
 
 jupyter labextension develop --overwrite '/home/ftp/naas/extensions/naasai'
 
+cd /home/ftp/
+
 # Start jupyterlab.
 tini -g -- "start-notebook.sh"  

--- a/naas/pipeline/pipeline.py
+++ b/naas/pipeline/pipeline.py
@@ -494,7 +494,6 @@ class DummyStep(Step):
     """
 
     def __init__(self, name):
-
         super().__init__(name)
         self.output = None
 

--- a/naas/pipeline/pipeline.py
+++ b/naas/pipeline/pipeline.py
@@ -570,7 +570,7 @@ class NotebookStep(Step):
             )
             self.status = StepStatus.COMPLETED
         except Exception as e:
-            self.status = StepStatus.ERRORED        
+            self.status = StepStatus.ERRORED
             if not self.on_error:
                 raise Exception(e)
 
@@ -580,4 +580,3 @@ class NotebookStep(Step):
             len(self.on_error.steps) > 0 or len(self.on_error.next_steps) > 0
         ):
             self.on_error.run(ctx)
-

--- a/naas/pipeline/pipeline.py
+++ b/naas/pipeline/pipeline.py
@@ -442,7 +442,7 @@ class Pipeline(Step):
         """
         if self.execution_ctx is not None:
             raise PipelineAlreadyRan("This pipeline have already been executed.")
-        self.execution_ctx = ExecutionContext()
+        self.execution_ctx = ExecutionContext(outputs_path)
         self.status = StepStatus.RUNNING
         self.monitors = []
         if monitor is True:

--- a/naas/pipeline/pipeline.py
+++ b/naas/pipeline/pipeline.py
@@ -39,7 +39,7 @@ class ExecutionContext:
     output_dir: str = None
     output_path: str = None
 
-    def __init__(self, output_dir: str = "pipeline_executions"):
+    def __init__(self, output_dir: str):
         self.execution_id = str(uuid.uuid4())
         self.output_dir = output_dir
         self.timestamp = datetime.datetime.now()
@@ -428,7 +428,7 @@ class Pipeline(Step):
         self,
         style: Literal["diagram", "progess"] = "diagram",
         monitor: bool = True,
-        outputs_path="",
+        outputs_path="pipeline_executions",
     ):
         """Start the execution of the pipeline.
 

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,8 @@ setup(
         "mprop==0.16.0",
         "pydash==5.1.0",
         "pyvis==0.3.0",
-        "rich"
+        "rich",
+        "tzlocal==2.1"
     ],
     classifiers=[
         "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
This Pull Request aims to allow users to define a custom path to store the results of their Pipeline executions. This is done by using the `outputs_path` parameter in the `run()` method of the `Pipeline` class.

Given below is an example of how this works,
```
from naas.pipeline.pipeline import (Pipeline, DummyStep,End)

pipeline = Pipeline()

step1 = DummyStep("Notebook 1")
step2 = DummyStep("Notebook 2")
step3 = DummyStep("Notebook 3")

pipeline >> step1 >> step2 >> step3 >> End()
pipeline.run(outputs_path='outputs')
```
As shown here, the `outputs` directory is created as specified above and the results of the pipeline executions are stored in separate sub-directories within it,
![image](https://github.com/jupyter-naas/naas/assets/49385643/01362760-69ed-44ce-b5c9-f77fc237c556)

The contents of the `outputs` directory,
![image](https://github.com/jupyter-naas/naas/assets/49385643/9119fce7-876b-440c-8cb5-28ed91163994)

If a path is not specified, the results will be stored within the `pipeline_executions` directory, by default.

Note: This directory is also visible in the above screenshot, because I have the run the Pipeline twice; once without specifying the `outputs_path` and a second time by passing the argument.